### PR TITLE
flask-limiter 3.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/limits-feedstock/pr3/f0e8d33

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/limits-feedstock/pr3/f0e8d33

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "flask-limiter" %}
 {% set version = "3.12" %}
-{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -11,17 +10,17 @@ source:
   sha256: f9e3e3d0c4acd0d1ffbfa729e17198dd1042f4d23c130ae160044fc930e21300
 
 build:
-  noarch: python
+  skip: True  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - pip
     - setuptools
   run:
-    - python >={{ python_min }}
+    - python
     - limits >=3.13
     - flask >=2
     - ordered-set >4,<5
@@ -33,7 +32,7 @@ test:
   commands:
     - pip check
   requires:
-    - python {{ python_min }}
+    - python
     - pip
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - wheel
   run:
     - python
     - limits >=3.13
@@ -42,6 +43,7 @@ about:
     Flask-Limiter adds rate limiting to Flask applications.
     By adding the extension to your flask application, you can configure various rate limits at different levels (e.g. application wide, per Blueprint, routes, resource etc).
   dev_url: https://github.com/alisaifee/flask-limiter
+  doc_url: https://flask-limiter.readthedocs.io
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,9 @@ test:
 about:
   home: https://flask-limiter.readthedocs.org
   summary: Rate limiting for flask applications
+  description: |
+    Flask-Limiter adds rate limiting to Flask applications.
+    By adding the extension to your flask application, you can configure various rate limits at different levels (e.g. application wide, per Blueprint, routes, resource etc).
   dev_url: https://github.com/alisaifee/flask-limiter
   license: MIT
   license_family: MIT


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-8016](https://anaconda.atlassian.net/browse/PKG-8016)
- [Upstream repository](https://github.com/alisaifee/flask-limiter/tree/3.12/tests)
- [Upstream changelog/diff](https://github.com/alisaifee/flask-limiter/releases)
- Relevant dependency PRs:
  - `flask-limiter` ➡️ `flask-appbuilder`

### Explanation of changes:

- Fork from conda forge
- Remove noarch
- Update python pinnings


[PKG-8016]: https://anaconda.atlassian.net/browse/PKG-8016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ